### PR TITLE
Clean include files for Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,19 @@ cntest
 new.out
 *.o
 build
+
+# Emacs temp files
+*~
+
+# Visual Stdio build directories
+Debug
+Release
+*.vcxproj
+*.vcxproj.filters
+
+# Output of CMake
+CMakeCache.txt
+CMakeFiles
+Makefile
+*.cmake
+install_manifest.txt

--- a/include/cn-cbor/cn-cbor.h
+++ b/include/cn-cbor/cn-cbor.h
@@ -16,7 +16,12 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#ifdef _MSC_VER
+#include <WinSock2.h>
+typedef long ssize_t;
+#else
 #include <unistd.h>
+#endif
 
 /**
  * All of the different kinds of CBOR values.

--- a/src/cbor.h
+++ b/src/cbor.h
@@ -1,6 +1,10 @@
 #ifndef CBOR_PROTOCOL_H__
 #define CBOR_PROTOCOL_H__
 
+#ifdef _MSC_VER
+#define inline _inline
+#endif
+
 /* The 8 major types */
 #define MT_UNSIGNED 0
 #define MT_NEGATIVE 1

--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -13,7 +13,11 @@ extern "C" {
 #include <string.h>
 #include <assert.h>
 #include <math.h>
+#ifdef _MSC_VER
+#include <WinSock2.h>
+#else
 #include <arpa/inet.h> // needed for ntohl (e.g.) on Linux
+#endif
 
 #include "cn-cbor/cn-cbor.h"
 #include "cbor.h"

--- a/src/cn-encoder.c
+++ b/src/cn-encoder.c
@@ -8,9 +8,15 @@ extern "C" {
 } /* Duh. */
 #endif
 
+#ifdef _MSC_VER
+#include <WinSock2.h>
+#else
 #include <arpa/inet.h>
+#endif
 #include <string.h>
+#ifndef _MSC_VER
 #include <strings.h>
+#endif
 #include <stdbool.h>
 #include <assert.h>
 


### PR DESCRIPTION
Use include files which exist on windows systems
define ssize_t since that is POSIX construct
define _inline as an alias for inline to work on windows
ignore more files dealing with the cmake system, Visual Studio build and
emacs
