### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+compiler:
+- clang
+- gcc
+env:
+- COVERAGE=true
+- COVERAGE=false;
+before_install:
+- sudo pip install cpp-coveralls
+- wget http://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz  -O /tmp/cmake.tar.gz
+- tar xzf /tmp/cmake.tar.gz
+- export PATH=$PWD/cmake-3.3.1-Linux-x86_64/bin/:$PATH
+script:
+- ./build.sh all test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: c
 compiler:
 - clang
 - gcc
-env:
-- COVERAGE=true
-- COVERAGE=false;
+sudo: false
 before_install:
-- sudo pip install cpp-coveralls
 - wget http://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz  -O /tmp/cmake.tar.gz
 - tar xzf /tmp/cmake.tar.gz
 - export PATH=$PWD/cmake-3.3.1-Linux-x86_64/bin/:$PATH


### PR DESCRIPTION
Sorry this is a two-patch PR.  Getting Travis working the first time always takes a couple of tries, and those tries have to be public.  To see the output from my repo: https://travis-ci.org/hildjj/cn-cbor

Once you've integrated this, you can go to https://travis-ci.org/auth, log in with your GitHub account, then go to https://travis-ci.org/profile, and turn on Travis for the cabo/cn-cbor project.

Once you get that far, and builds are working, I'll tackle coveralls to get coverage reports from each build.

Fixes #17 
