### PR TITLE
fix compilation error with gcc 7.2.0

### DIFF
--- a/src/cn-get.c
+++ b/src/cn-get.c
@@ -13,6 +13,7 @@ cn_cbor* cn_cbor_mapget_int(const cn_cbor* cb, int key) {
       if (cp->v.uint == (unsigned long)key) {
         return cp->next;
       }
+      break;
     case CN_CBOR_INT:
       if (cp->v.sint == (long)key) {
         return cp->next;


### PR DESCRIPTION
cn-cbor doesn't currently compile with gcc 7.2.0 on Arch Linux:

```
-- The C compiler identification is GNU 7.2.0
-- The CXX compiler identification is GNU 7.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
Build type: Debug
-- adding GCC/Clang options 
COVERALLS UPLOAD: OFF
-- Configuring done
-- Generating done
-- Build files have been written to: /srv/nfs/home/soeren/cn-cbor-upstream/build
Scanning dependencies of target cn-cbor
[ 12%] Building C object src/CMakeFiles/cn-cbor.dir/cn-encoder.c.o
[ 50%] Building C object src/CMakeFiles/cn-cbor.dir/cn-create.c.o
[ 50%] Building C object src/CMakeFiles/cn-cbor.dir/cn-error.c.o
[ 50%] Building C object src/CMakeFiles/cn-cbor.dir/cn-cbor.c.o
[ 62%] Building C object src/CMakeFiles/cn-cbor.dir/cn-get.c.o
/srv/nfs/home/soeren/cn-cbor-upstream/src/cn-get.c: In function ‘cn_cbor_mapget_int’:
/srv/nfs/home/soeren/cn-cbor-upstream/src/cn-get.c:13:10: error: this statement may fall through [-Werror=implicit-fallthrough=]
       if (cp->v.uint == (unsigned long)key) {
          ^
/srv/nfs/home/soeren/cn-cbor-upstream/src/cn-get.c:16:5: note: here
     case CN_CBOR_INT:
     ^~~~
cc1: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/cn-cbor.dir/build.make:159: src/CMakeFiles/cn-cbor.dir/cn-get.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:139: src/CMakeFiles/cn-cbor.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```

The fall through in the switch statement gcc complaints about didn't seem intentional to me therefore I decided to add an explicit `break` which fixes the error.