### PR TITLE
test: Fix declaration of main method

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -109,7 +109,7 @@ static void cn_cbor_decode_test(const unsigned char *buf, int len) {
   printf("%s at %d\n", err_name[back.err], back.pos);
 }
 
-int main() {
+int main(void) {
   char buf[100000];
   unsigned char *end;
   char *bufend;


### PR DESCRIPTION
After reading [cabos comment](https://github.com/cabo/cn-cbor/pull/44#issuecomment-361058463) in #44 I wondered if cn-cbor actually compiles with C compilers other than gcc and clang and tested this by compiling it with [pcc](http://pcc.ludd.ltu.se/) using the `Simple-Makefile`.

pcc complained that the function declaration for `main` in `test.c` is incorrect and according to section `5.1.2.2.1` of the C99 standard pcc is actually right about this.