### PR TITLE
implement alignment-safe ntoh16p() && ntoh32p()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ option ( coveralls      "Generate coveralls data" ON )
 option ( coveralls_send "Send data to coveralls site" OFF )
 option ( build_docs "Create docs using Doxygen" ${DOXYGEN_FOUND} )
 option ( no_floats "Build without floating point support" OFF )
-option ( align_memreads "Use memcpy in ntoh*p()" OFF )
+option ( align_reads    "Use memcpy in ntoh*p()" OFF )
 
 set ( dist_dir    ${CMAKE_BINARY_DIR}/dist )
 set ( prefix      ${CMAKE_INSTALL_PREFIX} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option ( coveralls      "Generate coveralls data" ON )
 option ( coveralls_send "Send data to coveralls site" OFF )
 option ( build_docs "Create docs using Doxygen" ${DOXYGEN_FOUND} )
 option ( no_floats "Build without floating point support" OFF )
+option ( align_memreads "Use memcpy in ntoh*p()" OFF )
 
 set ( dist_dir    ${CMAKE_BINARY_DIR}/dist )
 set ( prefix      ${CMAKE_INSTALL_PREFIX} )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,9 @@ set ( cbor_srcs
       cn-get.c
 )
 
+if (align_memreads)
+  add_definitions(-DCBOR_ALIGN_READS)
+endif()
 if (use_context)
   add_definitions(-DUSE_CBOR_CONTEXT)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ set ( cbor_srcs
       cn-get.c
 )
 
-if (align_memreads)
+if (align_reads)
   add_definitions(-DCBOR_ALIGN_READS)
 endif()
 if (use_context)

--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -49,8 +49,12 @@ static double decode_half(int half) {
 }
 #endif /* CBOR_NO_FLOAT */
 
-/* Fix these if you can't do non-aligned reads */
 #define ntoh8p(p) (*(unsigned char*)(p))
+
+#ifndef CBOR_ALIGN_MEMREADS
+#define ntoh16p(p) (ntohs(*(unsigned short*)(p)))
+#define ntoh32p(p) (ntohl(*(unsigned long*)(p)))
+#else
 static uint16_t ntoh16p(unsigned char *p) {
     uint16_t tmp;
     memcpy(&tmp, p, sizeof(tmp));
@@ -62,6 +66,7 @@ static uint32_t ntoh32p(unsigned char *p) {
     memcpy(&tmp, p, sizeof(tmp));
     return ntohl(tmp);
 }
+#endif
 
 static uint64_t ntoh64p(unsigned char *p) {
   uint64_t ret = ntoh32p(p);

--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -51,7 +51,7 @@ static double decode_half(int half) {
 
 #define ntoh8p(p) (*(unsigned char*)(p))
 
-#ifndef CBOR_ALIGN_MEMREADS
+#ifndef CBOR_ALIGN_READS
 #define ntoh16p(p) (ntohs(*(unsigned short*)(p)))
 #define ntoh32p(p) (ntohl(*(unsigned long*)(p)))
 #else
@@ -66,7 +66,7 @@ static uint32_t ntoh32p(unsigned char *p) {
     memcpy(&tmp, p, sizeof(tmp));
     return ntohl(tmp);
 }
-#endif
+#endif /* CBOR_ALIGN_READS */
 
 static uint64_t ntoh64p(unsigned char *p) {
   uint64_t ret = ntoh32p(p);

--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -51,8 +51,18 @@ static double decode_half(int half) {
 
 /* Fix these if you can't do non-aligned reads */
 #define ntoh8p(p) (*(unsigned char*)(p))
-#define ntoh16p(p) (ntohs(*(unsigned short*)(p)))
-#define ntoh32p(p) (ntohl(*(unsigned long*)(p)))
+static uint16_t ntoh16p(unsigned char *p) {
+    uint16_t tmp;
+    memcpy(&tmp, p, sizeof(tmp));
+    return ntohs(tmp);
+}
+
+static uint32_t ntoh32p(unsigned char *p) {
+    uint32_t tmp;
+    memcpy(&tmp, p, sizeof(tmp));
+    return ntohl(tmp);
+}
+
 static uint64_t ntoh64p(unsigned char *p) {
   uint64_t ret = ntoh32p(p);
   ret <<= 32;


### PR DESCRIPTION
Cortex-M platforms don't allow unaligned uint16_t or uint32_t accesses, leading to hard-faults.

This PR provides portable implementations for ntoh16p() and ntoh32p() using ~~malloc~~ memcpy.