### PR TITLE
cn_cbor_decode: set errp with CN_CBOR_NO_ERROR on success

### DIFF
--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -263,6 +263,8 @@ cn_cbor* cn_cbor_decode(const unsigned char* buf, size_t len CBOR_CONTEXT, cn_cb
   pb.err  = CN_CBOR_NO_ERROR;
   ret = decode_item(&pb CBOR_CONTEXT_PARAM, &catcher);
   if (ret != NULL) {
+    if (errp)
+        errp->err = CN_CBOR_NO_ERROR;
     /* mark as top node */
     ret->parent = NULL;
   } else {


### PR DESCRIPTION
for consistency, both
> if (errp->err == CN_CBOR_NO_ERROR)
and
> if (ret)
could be used to determine there was no error during decoding