### PR TITLE
Build with -Wswitch-default, and address warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ message ( "Build type: ${CMAKE_BUILD_TYPE}" )
 if ( CMAKE_C_COMPILER_ID STREQUAL "GNU" OR
      CMAKE_C_COMPILER_ID MATCHES "Clang" )
   message ( STATUS "adding GCC/Clang options ")
-  add_definitions ( -std=gnu99 -Wall -Wextra -pedantic )
+  add_definitions ( -std=gnu99 -Wall -Wextra -pedantic -Wswitch-default )
   if ( fatal_warnings )
     add_definitions ( -Werror )
   endif ()

--- a/src/cn-cbor.c
+++ b/src/cn-cbor.c
@@ -162,6 +162,8 @@ again:
     } else {
       CN_CBOR_FAIL(CN_CBOR_ERR_MT_UNDEF_FOR_INDEF);
     }
+  default:
+    break;
   }
   // process content
   switch (mt) {
@@ -222,6 +224,8 @@ again:
       break;
     default: cb->v.uint = val;
     }
+  default:
+    break;
   }
 fill:                           /* emulate loops */
   if (parent->flags & CN_CBOR_FL_INDEF) {

--- a/src/cn-encoder.c
+++ b/src/cn-encoder.c
@@ -285,6 +285,8 @@ void _encoder_visitor(const cn_cbor *cb, int depth, void *context)
   case CN_CBOR_INVALID:
     ws->offset = -1;
     break;
+  default:
+    break;
   }
 }
 


### PR DESCRIPTION
Some switch statements were missing default labels, this change adds [-Wswitch-default](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wswitch-default) to the GCC+Clang build config and fixes the resulting warnings. 