### PR TITLE
cn-encoder: Fix -Wdouble-promotion by explicit cast

### DIFF
--- a/src/cn-encoder.c
+++ b/src/cn-encoder.c
@@ -116,7 +116,7 @@ static void _write_positive(cn_write_state *ws, cn_cbor_type typ, uint64_t val) 
 static void _write_double(cn_write_state *ws, double val)
 {
   float float_val = val;
-  if (float_val == val) {                /* 32 bits is enough and we aren't NaN */
+  if ((double)float_val == val) { /* 32 bits is enough and we aren't NaN */
     uint32_t be32;
     uint16_t be16, u16;
     union {


### PR DESCRIPTION
The intention of this line of code is to check whether the conversion to float
reduced the precision of the value, hence the conversion to double is correct
here, but when compiled with GCC's -Wdouble-promotion, this implicit cast to
double will trigger a warning. The fix for the warning is to make the cast
explicit.