### PR TITLE
Bug fixed in cn-cbor library

### DIFF
--- a/src/cn-encoder.c
+++ b/src/cn-encoder.c
@@ -35,7 +35,7 @@ typedef struct _write_state
   ssize_t size;
 } cn_write_state;
 
-#define ensure_writable(sz) if ((ws->offset<0) || (ws->offset + (sz) >= ws->size)) { \
+#define ensure_writable(sz) if ((ws->offset<0) || (ws->offset + (sz) > ws->size)) { \
   ws->offset = -1; \
   return; \
 }


### PR DESCRIPTION
When encoding cn_cbor structure before writing any chunk of bytes into
buffer, library ensures that there is enough space to write current
chunk. It is done by the following inequality: offset+length >= size.
If inequality is true, then library decides that there is no enough space.
However, if offset+length == size then there is still enough space to
write a chunk of size length.